### PR TITLE
Fix SSL problem, string name, add test script.

### DIFF
--- a/Libraries/WebRequest2/InetHttp.mqh
+++ b/Libraries/WebRequest2/InetHttp.mqh
@@ -179,7 +179,7 @@ bool MqlNet::Request(tagRequest &req,uchar &inData[],uchar &outData[])
       hRequest=HttpOpenRequestW(hConnect,req.stVerb,req.stObject,Vers,nuller,nuller,INTERNET_FLAG_KEEP_CONNECTION|INTERNET_FLAG_RELOAD|INTERNET_FLAG_PRAGMA_NOCACHE,0);
      }
 //Get last error code
-   if(hRequest<=0) {lastError=kernel32::GetLastError(); Print("-Err OpenRequest "+(string) lastError); InternetCloseHandle(hConnect); return(false); }
+   if(hRequest<=0) {lastError=Kernel32::GetLastError(); Print("-Err OpenRequest "+(string) lastError); InternetCloseHandle(hConnect); return(false); }
 //Set certificate policity (warning this configuration is very unsecure and shouldn't be used where security matters!)
    if(req.trustSelf)
      {
@@ -191,7 +191,7 @@ bool MqlNet::Request(tagRequest &req,uchar &inData[],uchar &outData[])
       dwFlags|=SECURITY_FLAG_IGNORE_CERT_CN_INVALID;
       dwFlags|=SECURITY_FLAG_IGNORE_REVOCATION;
       bool rez=InternetSetOptionW(hRequest,INTERNET_OPTION_SECURITY_FLAGS,dwFlags,sizeof(dwFlags));
-      if(!rez) {lastError=kernel32::GetLastError(); Print("-Err SetOptionW "+(string)lastError); }
+      if(!rez) {lastError=Kernel32::GetLastError(); Print("-Err SetOptionW "+(string)lastError); }
      }
 // sending the request 
    int n=0;
@@ -202,7 +202,7 @@ bool MqlNet::Request(tagRequest &req,uchar &inData[],uchar &outData[])
       hSend=HttpSendRequestW(hRequest,req.stHead,StringLen(req.stHead),inData,ArraySize(inData));
       if(hSend<=0)
         {
-         lastError=kernel32::GetLastError(); Print("-Err SendRequest= ",(string) lastError);
+         lastError=Kernel32::GetLastError(); Print("-Err SendRequest= ",(string) lastError);
         }
       else break;
      }
@@ -240,7 +240,7 @@ int MqlNet::GetContentSize(int hRequest)
    if(!MQL5InfoInteger(MQL5_DLLS_ALLOWED)) { Print("-DLL not allowed"); return(false); } // checking whether DLLs are allowed in the terminal
    int len=32,ind=0; uchar buf[32];
    bool Res=HttpQueryInfoW(hRequest,HTTP_QUERY_CONTENT_LENGTH,buf,len,ind);
-   if(!Res) { int lastError=kernel32::GetLastError(); Print("-Err QueryInfo (Size)" + (string) lastError); return(-1); }
+   if(!Res) { int lastError=Kernel32::GetLastError(); Print("-Err QueryInfo (Size)" + (string) lastError); return(-1); }
 //This is a workaround because CharArrayToString does somehow not work...
    string s;
    for(int i=0;i<len;i++)
@@ -260,7 +260,7 @@ int MqlNet::GetHTTPStatusCode(int hRequest)
    int cBuffLength=32;
    int cBuffIndex=0;
    bool Res=HttpQueryInfoW(hRequest,HTTP_QUERY_STATUS_CODE,cBuff,cBuffLength,cBuffIndex);
-   if(!Res) { int lastError=kernel32::GetLastError(); Print("-Err QueryInfo (Status)" + (string) lastError); return(-1); }
+   if(!Res) { int lastError=Kernel32::GetLastError(); Print("-Err QueryInfo (Status)" + (string) lastError); return(-1); }
    string s="";
    for(int i=0;i<cBuffLength;i++)
      {

--- a/Libraries/WebRequest2/WebRequest2.mq5
+++ b/Libraries/WebRequest2/WebRequest2.mq5
@@ -7,7 +7,7 @@
 #property link      "https://github.com/sirtoobii"
 #property version		"1.00"
 #property library
-#include <..\Libraries\WebRequest2\InetHttp.mqh>
+#include "InetHttp.mqh"
 MqlNet INet;
 int  WebRequest2(
    const string      method,           // HTTP-Methode
@@ -53,15 +53,15 @@ int  WebRequest2(
       {
          Host = StringSubstr(lower_Url, 0, path_start);
          Path = StringSubstr(url, path_start+offset);
-         LogError(0, "Set Host to: " +Host+ " and Path: " +Path+ " with Port: " +IntegerToString(Port) + " SSL=" + (string) useSSL + " Insecure=" + (string) allowInsecure);
+         LogError(0, "Set Host to: " +Host+ " and Path: " +Path+ " with Port: " +IntegerToString(Port) + " SSL=" + (string) UseSSL + " Insecure=" + (string) allowInsecure);
       }else{
          Host = lower_Url;
-         LogError(0, "Set Host to: " +Host+ " with Port: " +IntegerToString(Port) + " SSL=" + (string) useSSL + " Insecure=" + (string) allowInsecure);
+         LogError(0, "Set Host to: " +Host+ " with Port: " +IntegerToString(Port) + " SSL=" + (string) UseSSL + " Insecure=" + (string) allowInsecure);
       }
       //Open connection
       if (!INet.Open(Host, Port, "", "", INTERNET_SERVICE_HTTP)) return -1;
-      if (method=="GET")  req.Init(method, Path,          Head, "",   false, file, false, useSSL, allowInsecure);
-      if (method=="POST") req.Init(method, Path,          Head, "", false, file, false, useSSL, allowInsecure);
+      if (method=="GET")  req.Init(method, Path,          Head, "",   false, file, false, UseSSL, allowInsecure);
+      if (method=="POST") req.Init(method, Path,          Head, "", false, file, false, UseSSL, allowInsecure);
       INet.Request(req, data, result);
       result_headers = req.resHeader;
       return req.resCode;

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ int  WebRequest2(
 #include <..\Libraries\WebRequest2\WebRequest2.mq5>
 ```
 
+ #### Test the library
+
+ You can use the script `Scripts/TestWebRequest2.mq5` as an example of how you can detect your Public IP by doing an HTTP/HTTPS request using this `WebRequest` library.
+
+ 1. Build the script `Scripts/TestWebRequest2.mq5` using MetaEditor
+ 2. Copy the file `TestWebRequest2.ex5` that has been built to the `Scripts` folder in your MetaTrader5 profile folder
+ 3. Open MetaTrader5 on a random chart
+ 4. Allow DLLs in your Terminal
+ 5. Load the script `TestWebRequest2.ex5` from the `Scripts` folder
+ 6. In the Terminal journal, verify that your Public IP address has been detected correctly
  
  #### Disclaimer
  You use this software at your own risk!

--- a/Scripts/TestWebRequest2.mq5
+++ b/Scripts/TestWebRequest2.mq5
@@ -1,0 +1,41 @@
+#property copyright     "Copyright 2023"
+#property link          ""
+#property version       "1.00"
+#property description   "TestWebRequest2"
+
+#include "../Libraries/WebRequest2/WebRequest2.mq5"
+
+// Input parameters
+input string Input_HTTP_URL = "http://ifconfig.me/ip";
+input string Input_HTTPS_URL = "https://ifconfig.me/ip";
+
+void OnStart() {
+   string RequestHeaders = "";
+   char Data[];
+   char HTTPResult[];
+   char HTTPSResult[];
+   string HTTPResultHeaders;
+   string HTTPSResultHeaders;
+   int HTTPResponseCode;
+   int HTTPSResponseCode;
+   int TimeoutInMs = 1000;
+
+   // Send the HTTP request
+   HTTPResponseCode = WebRequest2("GET", Input_HTTP_URL, RequestHeaders, TimeoutInMs, Data, HTTPResult, HTTPResultHeaders);
+
+   // Show the HTTP response
+   Print("HTTP Response Code:" + (string) HTTPResponseCode);
+   Print("HTTP Response:");
+   Print(CharArrayToString(HTTPResult));
+
+   // Sleep 2 seconds
+   Sleep(2000);
+
+   // Send the HTTPS request
+   HTTPSResponseCode = WebRequest2("GET", Input_HTTPS_URL, RequestHeaders, TimeoutInMs, Data, HTTPSResult, HTTPSResultHeaders);
+
+   // Show the HTTPS response
+   Print("HTTPS Response Code:" + (string) HTTPSResponseCode);
+   Print("HTTPS Response:");
+   Print(CharArrayToString(HTTPSResult));
+}


### PR DESCRIPTION
Since the files were not encoded in UTF-8, they were considered binary files, so we can't see the diffs correctly on git.

The first thing I did in this PR was to convert the files to UTF-8, so we can then see the diffs.

The other changes in this PR are:
- Fix a typo in the `UseSSL` variable that was preventing from doing SSL requests
- Rename the string `kernel32` to `Kernel32`, as it seems like MT5 is now complaining about that
- Added a simple test script that can show that things are working fine

You can see the changes in detail by looking at the commits.

Here is the output of the test script:
```bash
21:00:46.572	TestWebRequest2 (EURUSD,H1)	http://ifconfig.me/ip
21:00:46.572	TestWebRequest2 (EURUSD,H1)	++Webrequest2[INFO] Set Host to: ifconfig.me and Path: /ip with Port: 80 SSL=false Insecure=false
21:00:46.572	TestWebRequest2 (EURUSD,H1)	+Open Inet...
21:00:46.713	TestWebRequest2 (EURUSD,H1)	HTTP Response Code:200
21:00:46.713	TestWebRequest2 (EURUSD,H1)	HTTP Response:
21:00:46.713	TestWebRequest2 (EURUSD,H1)	194.106.XX.XX

21:00:48.701	TestWebRequest2 (EURUSD,H1)	https://ifconfig.me/ip
21:00:48.701	TestWebRequest2 (EURUSD,H1)	++Webrequest2[INFO] Set Host to: ifconfig.me and Path: /ip with Port: 443 SSL=true Insecure=false
21:00:48.701	TestWebRequest2 (EURUSD,H1)	-Close Session...
21:00:48.701	TestWebRequest2 (EURUSD,H1)	-Close Connect...
21:00:48.701	TestWebRequest2 (EURUSD,H1)	+Open Inet...
21:00:48.862	TestWebRequest2 (EURUSD,H1)	HTTPS Response Code:200
21:00:48.862	TestWebRequest2 (EURUSD,H1)	HTTPS Response:
21:00:48.862	TestWebRequest2 (EURUSD,H1)	194.106.XX.XX

21:00:48.862	TestWebRequest2 (EURUSD,H1)	-Close Session...
21:00:48.862	TestWebRequest2 (EURUSD,H1)	-Close Connect...
21:00:48.862	TestWebRequest2 (EURUSD,H1)	18 leaked strings left
```