### PR TITLE
clang-format files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,17 @@
+# Commands to use :
+# clang-format -i *.mqh
+# clang-format -i *.mq5
+
+# Options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+BasedOnStyle: LLVM
+IndentWidth: 3
+ColumnLimit: 200
+SpaceAfterCStyleCast: true
+UseTab: Never
+AllowShortIfStatementsOnASingleLine: false
+AlignTrailingComments: true
+SpacesBeforeTrailingComments: 3
+AlwaysBreakAfterReturnType: None
+AlignConsecutiveMacros: Consecutive
+UseCRLF: false

--- a/Libraries/WebRequest2/InetHttp.mqh
+++ b/Libraries/WebRequest2/InetHttp.mqh
@@ -7,295 +7,360 @@
 //|     programming & support - Alexey Sergeev (profy.mql@gmail.com) |
 //+------------------------------------------------------------------+
 #property copyright "Copyright © 2010, FXmaster.de,Copyright © 2018, T.Bossert"
-#property link      "www.FXmaster.de,https://github.com/sirtoobii"
-#property version		"1.01"
-#property description  "WinHttp & WinInet API"
+#property link "www.FXmaster.de,https://github.com/sirtoobii"
+#property version "1.01"
+#property description "WinHttp & WinInet API"
 #property library
 
 #define FALSE 0
 
-#define HINTERNET int
-#define BOOL int
-#define INTERNET_PORT int
+#define HINTERNET          int
+#define BOOL               int
+#define INTERNET_PORT      int
 #define LPINTERNET_BUFFERS int
-#define DWORD int
-#define DWORD_PTR int
-#define LPDWORD int&
-#define LPVOID uchar& 
-#define LPSTR string
-#define LPCWSTR	string&
-#define LPCTSTR string&
-#define LPTSTR string&
+#define DWORD              int
+#define DWORD_PTR          int
+#define LPDWORD            int &
+#define LPVOID             uchar &
+#define LPSTR              string
+#define LPCWSTR            string &
+#define LPCTSTR            string &
+#define LPTSTR             string &
 
-#import	"Kernel32.dll"
+#import "Kernel32.dll"
 DWORD GetLastError(void);
 #import
 
 #import "wininet.dll"
 DWORD InternetAttemptConnect(DWORD dwReserved);
-HINTERNET InternetOpenW(LPCTSTR lpszAgent,DWORD dwAccessType,LPCTSTR lpszProxyName,LPCTSTR lpszProxyBypass,DWORD dwFlags);
-HINTERNET InternetConnectW(HINTERNET hInternet,LPCTSTR lpszServerName,INTERNET_PORT nServerPort,LPCTSTR lpszUsername,LPCTSTR lpszPassword,DWORD dwService,DWORD dwFlags,DWORD_PTR dwContext);
-HINTERNET HttpOpenRequestW(HINTERNET hConnect,LPCTSTR lpszVerb,LPCTSTR lpszObjectName,LPCTSTR lpszVersion,LPCTSTR lpszReferer,LPCTSTR lplpszAcceptTypes,uint/*DWORD*/ dwFlags,DWORD_PTR dwContext);
-BOOL HttpSendRequestW(HINTERNET hRequest,LPCTSTR lpszHeaders,DWORD dwHeadersLength,LPVOID lpOptional[],DWORD dwOptionalLength);
-BOOL HttpQueryInfoW(HINTERNET hRequest,DWORD dwInfoLevel,LPVOID lpvBuffer[],LPDWORD lpdwBufferLength,LPDWORD lpdwIndex);
-HINTERNET InternetOpenUrlW(HINTERNET hInternet,LPCTSTR lpszUrl,LPCTSTR lpszHeaders,DWORD dwHeadersLength,uint/*DWORD*/ dwFlags,DWORD_PTR dwContext);
-BOOL InternetReadFile(HINTERNET hFile,LPVOID lpBuffer[],DWORD dwNumberOfBytesToRead,LPDWORD lpdwNumberOfBytesRead);
+HINTERNET InternetOpenW(LPCTSTR lpszAgent, DWORD dwAccessType, LPCTSTR lpszProxyName, LPCTSTR lpszProxyBypass, DWORD dwFlags);
+HINTERNET InternetConnectW(HINTERNET hInternet, LPCTSTR lpszServerName, INTERNET_PORT nServerPort, LPCTSTR lpszUsername, LPCTSTR lpszPassword, DWORD dwService, DWORD dwFlags, DWORD_PTR dwContext);
+HINTERNET HttpOpenRequestW(HINTERNET hConnect, LPCTSTR lpszVerb, LPCTSTR lpszObjectName, LPCTSTR lpszVersion, LPCTSTR lpszReferer, LPCTSTR lplpszAcceptTypes, uint /*DWORD*/ dwFlags,
+                           DWORD_PTR dwContext);
+BOOL HttpSendRequestW(HINTERNET hRequest, LPCTSTR lpszHeaders, DWORD dwHeadersLength, LPVOID lpOptional[], DWORD dwOptionalLength);
+BOOL HttpQueryInfoW(HINTERNET hRequest, DWORD dwInfoLevel, LPVOID lpvBuffer[], LPDWORD lpdwBufferLength, LPDWORD lpdwIndex);
+HINTERNET InternetOpenUrlW(HINTERNET hInternet, LPCTSTR lpszUrl, LPCTSTR lpszHeaders, DWORD dwHeadersLength, uint /*DWORD*/ dwFlags, DWORD_PTR dwContext);
+BOOL InternetReadFile(HINTERNET hFile, LPVOID lpBuffer[], DWORD dwNumberOfBytesToRead, LPDWORD lpdwNumberOfBytesRead);
 BOOL InternetCloseHandle(HINTERNET hInternet);
-BOOL InternetSetOptionW(HINTERNET hInternet,DWORD dwOption,LPDWORD lpBuffer,DWORD dwBufferLength);
-BOOL InternetQueryOptionW(HINTERNET hInternet,DWORD dwOption,LPDWORD lpBuffer,LPDWORD lpdwBufferLength);
+BOOL InternetSetOptionW(HINTERNET hInternet, DWORD dwOption, LPDWORD lpBuffer, DWORD dwBufferLength);
+BOOL InternetQueryOptionW(HINTERNET hInternet, DWORD dwOption, LPDWORD lpBuffer, LPDWORD lpdwBufferLength);
 #import
 
-#define OPEN_TYPE_PRECONFIG		0   // use default configuration
-#define INTERNET_SERVICE_FTP						1 // Ftp service
-#define INTERNET_SERVICE_HTTP						3	// Http service 
-#define HTTP_QUERY_CONTENT_LENGTH 			5
-#define HTTP_QUERY_STATUS_CODE            19 //Http status code
-#define HTTP_QUERY_RAW_HEADERS_CRLF            22  //Response Headers
+#define OPEN_TYPE_PRECONFIG         0               // use default configuration
+#define INTERNET_SERVICE_FTP        1               // Ftp service
+#define INTERNET_SERVICE_HTTP       3               // Http service
+#define HTTP_QUERY_CONTENT_LENGTH   5
+#define HTTP_QUERY_STATUS_CODE      19              // Http status code
+#define HTTP_QUERY_RAW_HEADERS_CRLF 22              // Response Headers
 
-#define INTERNET_FLAG_PRAGMA_NOCACHE						0x00000100  // no caching of page
-#define INTERNET_FLAG_KEEP_CONNECTION						0x00400000  // keep connection
-#define INTERNET_FLAG_SECURE            				0x00800000     //SSL TLS
-#define INTERNET_FLAG_RELOAD										0x80000000  // get page from server when calling it
-#define INTERNET_OPTION_SECURITY_FLAGS    	     31
+#define INTERNET_FLAG_PRAGMA_NOCACHE   0x00000100   // no caching of page
+#define INTERNET_FLAG_KEEP_CONNECTION  0x00400000   // keep connection
+#define INTERNET_FLAG_SECURE           0x00800000   // SSL TLS
+#define INTERNET_FLAG_RELOAD           0x80000000   // get page from server when calling it
+#define INTERNET_OPTION_SECURITY_FLAGS 31
 
-
-#define ERROR_INTERNET_INVALID_CA								12045
-#define INTERNET_FLAG_IGNORE_CERT_DATE_INVALID  0x00002000
-#define INTERNET_FLAG_IGNORE_CERT_CN_INVALID    0x00001000
-#define SECURITY_FLAG_IGNORE_CERT_CN_INVALID    INTERNET_FLAG_IGNORE_CERT_CN_INVALID
-#define SECURITY_FLAG_IGNORE_CERT_DATE_INVALID  INTERNET_FLAG_IGNORE_CERT_DATE_INVALID
-#define SECURITY_FLAG_IGNORE_REVOCATION         0x00000080
-#define SECURITY_FLAG_IGNORE_UNKNOWN_CA         0x00000100
-#define SECURITY_FLAG_IGNORE_WRONG_USAGE        0x00000200
+#define ERROR_INTERNET_INVALID_CA              12045
+#define INTERNET_FLAG_IGNORE_CERT_DATE_INVALID 0x00002000
+#define INTERNET_FLAG_IGNORE_CERT_CN_INVALID   0x00001000
+#define SECURITY_FLAG_IGNORE_CERT_CN_INVALID   INTERNET_FLAG_IGNORE_CERT_CN_INVALID
+#define SECURITY_FLAG_IGNORE_CERT_DATE_INVALID INTERNET_FLAG_IGNORE_CERT_DATE_INVALID
+#define SECURITY_FLAG_IGNORE_REVOCATION        0x00000080
+#define SECURITY_FLAG_IGNORE_UNKNOWN_CA        0x00000100
+#define SECURITY_FLAG_IGNORE_WRONG_USAGE       0x00000200
 //------------------------------------------------------------------ struct tagRequest
-struct tagRequest
-  {
-   string            stVerb; // method of the GET/POST request
-   string            stObject; // path to the page "/get.php?a=1" or "/index.htm"
-   string            stHead; // request header, 
-                             // "Content-Type: multipart/form-data; boundary=1BEF0A57BE110FD467A\r\n"
+struct tagRequest {
+   string stVerb;     // method of the GET/POST request
+   string stObject;   // path to the page "/get.php?a=1" or "/index.htm"
+   string stHead;     // request header,
+                      // "Content-Type: multipart/form-data; boundary=1BEF0A57BE110FD467A\r\n"
    // or "Content-Type: application/x-www-form-urlencoded"
-   string            stData; // additional string of information
-   bool              fromFile; // if =true, then stData is the name of the data file
-   string            stOut; // field for receiving the answer
-   bool              toFile; // if =true, then stOut is the name of file for receiving the answer
-   int               resCode; // HTTP response code
-   string            resHeader; //Raw Response Header (max 1024 Bytes)
-   bool              useSSL;   //Use secure connection
-   bool              trustSelf; //Trust self signed
-   void              Init(string aVerb,string aObject,string aHead,string aData,bool from,string aOut,bool to,bool uSSL,bool sSign);
-  };
+   string stData;      // additional string of information
+   bool fromFile;      // if =true, then stData is the name of the data file
+   string stOut;       // field for receiving the answer
+   bool toFile;        // if =true, then stOut is the name of file for receiving the answer
+   int resCode;        // HTTP response code
+   string resHeader;   // Raw Response Header (max 1024 Bytes)
+   bool useSSL;        // Use secure connection
+   bool trustSelf;     // Trust self signed
+   void Init(string aVerb, string aObject, string aHead, string aData, bool from, string aOut, bool to, bool uSSL, bool sSign);
+};
 //------------------------------------------------------------------ class MqlNet
-void tagRequest::Init(string aVerb,string aObject,string aHead,string aData,bool from,string aOut,bool to,bool uSSL,bool sSign)
-  {
-   stVerb=aVerb; // method of the GET/POST request
-   stObject=aObject; // path to the page "/get.php?a=1" or "/index.htm"
-   stHead=aHead; // request header, "Content-Type: application/x-www-form-urlencoded"
-   stData=aData; // additional string of information
-   fromFile=from; // if =true, then stData is the name of the data file
-   stOut=aOut; // field for receiving the answer
-   toFile=to; // if =true, then stOut is the name of file for receiving the answer
-   resCode=-1;
-   resHeader="";
-   useSSL=uSSL;
-   trustSelf=sSign;
-  }
+void tagRequest::Init(string aVerb, string aObject, string aHead, string aData, bool from, string aOut, bool to, bool uSSL, bool sSign) {
+   stVerb = aVerb;       // method of the GET/POST request
+   stObject = aObject;   // path to the page "/get.php?a=1" or "/index.htm"
+   stHead = aHead;       // request header, "Content-Type: application/x-www-form-urlencoded"
+   stData = aData;       // additional string of information
+   fromFile = from;      // if =true, then stData is the name of the data file
+   stOut = aOut;         // field for receiving the answer
+   toFile = to;          // if =true, then stOut is the name of file for receiving the answer
+   resCode = -1;
+   resHeader = "";
+   useSSL = uSSL;
+   trustSelf = sSign;
+}
 //------------------------------------------------------------------ class MqlNet
-class MqlNet
-  {
-public:
-   string            Host; // host name
-   int               Port; // port
-   string            User; // user name
-   string            Pass; // user password
-   int               Service; // service type 
-                              // obtained parameters
-   int               hSession; // session descriptor
-   int               hConnect; // connection descriptor
-public:
-                     MqlNet(); // class constructor
-                    ~MqlNet(); // destructor
-   bool              Open(string aHost,int aPort,string aUser,string aPass,int aService); // create a session and open a connection
-   void              Close(); // close the session and the connection
-   bool              Request(tagRequest &req,uchar &inData[],uchar &outData[]); // send the request
-   void              ReadPage(int hRequest,uchar &outData[]);
-   int               GetContentSize(int hURL); //get information about the size of downloaded page
-   string            GetHTTPHeaders(int hRequest); // Get all result headers
-   int               GetHTTPStatusCode(int hRequest); //returns the status code of a request
-   bool              CheckTerminal();  //Checks terminal if DLL's are allowed
-  };
+class MqlNet {
+ public:
+   string Host;                                                                    // host name
+   int Port;                                                                       // port
+   string User;                                                                    // user name
+   string Pass;                                                                    // user password
+   int Service;                                                                    // service type
+                                                                                   // obtained parameters
+   int hSession;                                                                   // session descriptor
+   int hConnect;                                                                   // connection descriptor
+ public:
+   MqlNet();                                                                       // class constructor
+   ~MqlNet();                                                                      // destructor
+   bool Open(string aHost, int aPort, string aUser, string aPass, int aService);   // create a session and open a connection
+   void Close();                                                                   // close the session and the connection
+   bool Request(tagRequest &req, uchar &inData[], uchar &outData[]);               // send the request
+   void ReadPage(int hRequest, uchar &outData[]);
+   int GetContentSize(int hURL);                                                   // get information about the size of downloaded page
+   string GetHTTPHeaders(int hRequest);                                            // Get all result headers
+   int GetHTTPStatusCode(int hRequest);                                            // returns the status code of a request
+   bool CheckTerminal();                                                           // Checks terminal if DLL's are allowed
+};
 //------------------------------------------------------------------ MqlNet
-void MqlNet::MqlNet()
-  {
-   hSession=-1; hConnect=-1; Host=""; User=""; Pass=""; Service=-1; // zeroize the parameters
-  }
+void MqlNet::MqlNet() {
+   hSession = -1;
+   hConnect = -1;
+   Host = "";
+   User = "";
+   Pass = "";
+   Service = -1;   // zeroize the parameters
+}
 //------------------------------------------------------------------ ~MqlNet
-void MqlNet::~MqlNet()
-  {
-   Close(); // close all descriptors 
-  }
+void MqlNet::~MqlNet() {
+   Close();   // close all descriptors
+}
 //------------------------------------------------------------------ Open
-bool MqlNet::Open(string aHost,int aPort,string aUser,string aPass,int aService)
-  {
-   if(aHost=="") { Print("-Host not specified"); return(false); }
-   if(!TerminalInfoInteger(TERMINAL_DLLS_ALLOWED)) { Print("-DLL not allowed"); return(false); } // checking whether DLLs are allowed in the terminal
-   if(!MQL5InfoInteger(MQL5_DLLS_ALLOWED)) { Print("-DLL not allowed"); return(false); } // checking whether DLLs are allowed in the terminal
-   if(hSession>0 || hConnect>0) Close(); // close if a session was determined 
-   Print("+Open Inet..."); // print a message about the attempt of opening in the journal
-   if(InternetAttemptConnect(0)!=0) { Print("-Err AttemptConnect"); return(false); } // exit if the attempt to check the current Internet connection failed
-   string UserAgent="Metatrader 5"; string nill="";
-   hSession=InternetOpenW(UserAgent,OPEN_TYPE_PRECONFIG,nill,nill,0); // open session
-   if(hSession<=0) { Print("-Err create Session"); Close(); return(false); } // exit if the attempt to open the session failed
-   hConnect=InternetConnectW(hSession,aHost,aPort,aUser,aPass,aService,0,0);
-   if(hConnect<=0) { Print("-Err create Connect"); Close(); return(false); }
-   Host=aHost; Port=aPort; User=aUser; Pass=aPass; Service=aService;
-   return(true); // otherwise all the checks are successfully finished
-  }
+bool MqlNet::Open(string aHost, int aPort, string aUser, string aPass, int aService) {
+   if (aHost == "") {
+      Print("-Host not specified");
+      return (false);
+   }
+   if (!TerminalInfoInteger(TERMINAL_DLLS_ALLOWED)) {
+      Print("-DLL not allowed");
+      return (false);
+   }   // checking whether DLLs are allowed in the terminal
+   if (!MQL5InfoInteger(MQL5_DLLS_ALLOWED)) {
+      Print("-DLL not allowed");
+      return (false);
+   }                         // checking whether DLLs are allowed in the terminal
+   if (hSession > 0 || hConnect > 0)
+      Close();               // close if a session was determined
+   Print("+Open Inet...");   // print a message about the attempt of opening in the journal
+   if (InternetAttemptConnect(0) != 0) {
+      Print("-Err AttemptConnect");
+      return (false);
+   }   // exit if the attempt to check the current Internet connection failed
+   string UserAgent = "Metatrader 5";
+   string nill = "";
+   hSession = InternetOpenW(UserAgent, OPEN_TYPE_PRECONFIG, nill, nill, 0);   // open session
+   if (hSession <= 0) {
+      Print("-Err create Session");
+      Close();
+      return (false);
+   }   // exit if the attempt to open the session failed
+   hConnect = InternetConnectW(hSession, aHost, aPort, aUser, aPass, aService, 0, 0);
+   if (hConnect <= 0) {
+      Print("-Err create Connect");
+      Close();
+      return (false);
+   }
+   Host = aHost;
+   Port = aPort;
+   User = aUser;
+   Pass = aPass;
+   Service = aService;
+   return (true);   // otherwise all the checks are successfully finished
+}
 //------------------------------------------------------------------ Close
-void MqlNet::Close()
-  {
-   if(hSession>0) { InternetCloseHandle(hSession); hSession=-1; Print("-Close Session..."); }
-   if(hConnect>0) { InternetCloseHandle(hConnect); hConnect=-1; Print("-Close Connect..."); }
-  }
+void MqlNet::Close() {
+   if (hSession > 0) {
+      InternetCloseHandle(hSession);
+      hSession = -1;
+      Print("-Close Session...");
+   }
+   if (hConnect > 0) {
+      InternetCloseHandle(hConnect);
+      hConnect = -1;
+      Print("-Close Connect...");
+   }
+}
 //------------------------------------------------------------------ Request
-bool MqlNet::Request(tagRequest &req,uchar &inData[],uchar &outData[])
-  {
-   if(!CheckTerminal()) return false;
+bool MqlNet::Request(tagRequest &req, uchar &inData[], uchar &outData[]) {
+   if (!CheckTerminal())
+      return false;
    uchar data[];
    int hRequest;
-   int hSend=0;
-   string Vers="HTTP/1.1";
-   string nill="";
-   int lastError=0;
-   if(hSession<=0 || hConnect<=0) { Close(); if(!Open(Host,Port,User,Pass,Service)) { Print("-Err Connect"); Close(); return(false); } }
-   string nuller=NULL;
-//creating descriptor of the request
-   if(req.useSSL)
-     {
-      hRequest=HttpOpenRequestW(hConnect,req.stVerb,req.stObject,Vers,nuller,nuller,INTERNET_FLAG_KEEP_CONNECTION|INTERNET_FLAG_RELOAD|INTERNET_FLAG_PRAGMA_NOCACHE|INTERNET_FLAG_SECURE,0);
-     }
-   else
-     {
-      hRequest=HttpOpenRequestW(hConnect,req.stVerb,req.stObject,Vers,nuller,nuller,INTERNET_FLAG_KEEP_CONNECTION|INTERNET_FLAG_RELOAD|INTERNET_FLAG_PRAGMA_NOCACHE,0);
-     }
-//Get last error code
-   if(hRequest<=0) {lastError=Kernel32::GetLastError(); Print("-Err OpenRequest "+(string) lastError); InternetCloseHandle(hConnect); return(false); }
-//Set certificate policity (warning this configuration is very unsecure and shouldn't be used where security matters!)
-   if(req.trustSelf)
-     {
+   int hSend = 0;
+   string Vers = "HTTP/1.1";
+   string nill = "";
+   int lastError = 0;
+   if (hSession <= 0 || hConnect <= 0) {
+      Close();
+      if (!Open(Host, Port, User, Pass, Service)) {
+         Print("-Err Connect");
+         Close();
+         return (false);
+      }
+   }
+   string nuller = NULL;
+   // creating descriptor of the request
+   if (req.useSSL) {
+      hRequest =
+          HttpOpenRequestW(hConnect, req.stVerb, req.stObject, Vers, nuller, nuller, INTERNET_FLAG_KEEP_CONNECTION | INTERNET_FLAG_RELOAD | INTERNET_FLAG_PRAGMA_NOCACHE | INTERNET_FLAG_SECURE, 0);
+   } else {
+      hRequest = HttpOpenRequestW(hConnect, req.stVerb, req.stObject, Vers, nuller, nuller, INTERNET_FLAG_KEEP_CONNECTION | INTERNET_FLAG_RELOAD | INTERNET_FLAG_PRAGMA_NOCACHE, 0);
+   }
+   // Get last error code
+   if (hRequest <= 0) {
+      lastError = Kernel32::GetLastError();
+      Print("-Err OpenRequest " + (string) lastError);
+      InternetCloseHandle(hConnect);
+      return (false);
+   }
+   // Set certificate policity (warning this configuration is very unsecure and shouldn't be used where security matters!)
+   if (req.trustSelf) {
       int dwFlags;
-      int dwBuffLen=sizeof(dwFlags);
-      InternetQueryOptionW(hRequest,INTERNET_OPTION_SECURITY_FLAGS,dwFlags,dwBuffLen);
-      dwFlags|=SECURITY_FLAG_IGNORE_UNKNOWN_CA;
-      dwFlags|=INTERNET_FLAG_IGNORE_CERT_DATE_INVALID;
-      dwFlags|=SECURITY_FLAG_IGNORE_CERT_CN_INVALID;
-      dwFlags|=SECURITY_FLAG_IGNORE_REVOCATION;
-      bool rez=InternetSetOptionW(hRequest,INTERNET_OPTION_SECURITY_FLAGS,dwFlags,sizeof(dwFlags));
-      if(!rez) {lastError=Kernel32::GetLastError(); Print("-Err SetOptionW "+(string)lastError); }
-     }
-// sending the request 
-   int n=0;
-   while(n<3)
-     {
+      int dwBuffLen = sizeof(dwFlags);
+      InternetQueryOptionW(hRequest, INTERNET_OPTION_SECURITY_FLAGS, dwFlags, dwBuffLen);
+      dwFlags |= SECURITY_FLAG_IGNORE_UNKNOWN_CA;
+      dwFlags |= INTERNET_FLAG_IGNORE_CERT_DATE_INVALID;
+      dwFlags |= SECURITY_FLAG_IGNORE_CERT_CN_INVALID;
+      dwFlags |= SECURITY_FLAG_IGNORE_REVOCATION;
+      bool rez = InternetSetOptionW(hRequest, INTERNET_OPTION_SECURITY_FLAGS, dwFlags, sizeof(dwFlags));
+      if (!rez) {
+         lastError = Kernel32::GetLastError();
+         Print("-Err SetOptionW " + (string) lastError);
+      }
+   }
+   // sending the request
+   int n = 0;
+   while (n < 3) {
       n++;
-      //send 
-      hSend=HttpSendRequestW(hRequest,req.stHead,StringLen(req.stHead),inData,ArraySize(inData));
-      if(hSend<=0)
-        {
-         lastError=Kernel32::GetLastError(); Print("-Err SendRequest= ",(string) lastError);
-        }
-      else break;
-     }
-   if(hSend>0)
-     {
-      req.resCode=GetHTTPStatusCode(hRequest); //Get response code
-      req.resHeader= GetHTTPHeaders(hRequest); //Get Header
-      ReadPage(hRequest,outData); //Read data from server
-     }
-   InternetCloseHandle(hRequest); InternetCloseHandle(hSend); // close all handles
-   if(hSend<=0) Close();
-   return(true);
-  }
+      // send
+      hSend = HttpSendRequestW(hRequest, req.stHead, StringLen(req.stHead), inData, ArraySize(inData));
+      if (hSend <= 0) {
+         lastError = Kernel32::GetLastError();
+         Print("-Err SendRequest= ", (string) lastError);
+      } else
+         break;
+   }
+   if (hSend > 0) {
+      req.resCode = GetHTTPStatusCode(hRequest);   // Get response code
+      req.resHeader = GetHTTPHeaders(hRequest);    // Get Header
+      ReadPage(hRequest, outData);                 // Read data from server
+   }
+   InternetCloseHandle(hRequest);
+   InternetCloseHandle(hSend);   // close all handles
+   if (hSend <= 0)
+      Close();
+   return (true);
+}
 //------------------------------------------------------------------ ReadPage
-void MqlNet::ReadPage(int hRequest,uchar &outData[])
-  {
-   if(!CheckTerminal()) return;
-// read the page 
-   int bufferSize=100;
-   uchar ch[100]; string toStr=""; int dwBytes,h=-1;
-   long content_size=GetContentSize(hRequest);
-   ArrayResize(outData,GetContentSize(hRequest));
-   int index=0;
-   while(InternetReadFile(hRequest,ch,bufferSize,dwBytes))
-     {
-      if(dwBytes<=0) break;
-      for(int i=0; i<dwBytes; i++) {outData[i+index]=ch[i];}
-      index+=dwBytes;
-     }
-  }
+void MqlNet::ReadPage(int hRequest, uchar &outData[]) {
+   if (!CheckTerminal())
+      return;
+   // read the page
+   int bufferSize = 100;
+   uchar ch[100];
+   string toStr = "";
+   int dwBytes, h = -1;
+   long content_size = GetContentSize(hRequest);
+   ArrayResize(outData, GetContentSize(hRequest));
+   int index = 0;
+   while (InternetReadFile(hRequest, ch, bufferSize, dwBytes)) {
+      if (dwBytes <= 0)
+         break;
+      for (int i = 0; i < dwBytes; i++) {
+         outData[i + index] = ch[i];
+      }
+      index += dwBytes;
+   }
+}
 //------------------------------------------------------------------ GetContentSize
-int MqlNet::GetContentSize(int hRequest)
-  {
-   if(!TerminalInfoInteger(TERMINAL_DLLS_ALLOWED)) { Print("-DLL not allowed"); return(false); } // checking whether DLLs are allowed in the terminal
-   if(!MQL5InfoInteger(MQL5_DLLS_ALLOWED)) { Print("-DLL not allowed"); return(false); } // checking whether DLLs are allowed in the terminal
-   int len=32,ind=0; uchar buf[32];
-   bool Res=HttpQueryInfoW(hRequest,HTTP_QUERY_CONTENT_LENGTH,buf,len,ind);
-   if(!Res) { int lastError=Kernel32::GetLastError(); Print("-Err QueryInfo (Size)" + (string) lastError); return(-1); }
-//This is a workaround because CharArrayToString does somehow not work...
+int MqlNet::GetContentSize(int hRequest) {
+   if (!TerminalInfoInteger(TERMINAL_DLLS_ALLOWED)) {
+      Print("-DLL not allowed");
+      return (false);
+   }   // checking whether DLLs are allowed in the terminal
+   if (!MQL5InfoInteger(MQL5_DLLS_ALLOWED)) {
+      Print("-DLL not allowed");
+      return (false);
+   }   // checking whether DLLs are allowed in the terminal
+   int len = 32, ind = 0;
+   uchar buf[32];
+   bool Res = HttpQueryInfoW(hRequest, HTTP_QUERY_CONTENT_LENGTH, buf, len, ind);
+   if (!Res) {
+      int lastError = Kernel32::GetLastError();
+      Print("-Err QueryInfo (Size)" + (string) lastError);
+      return (-1);
+   }
+   // This is a workaround because CharArrayToString does somehow not work...
    string s;
-   for(int i=0;i<len;i++)
-     {
-      StringAdd(s,CharToString(buf[i]));
-     }
-//ToDo Overflow prodection!
-   return((int)StringToInteger(s));
-  }
+   for (int i = 0; i < len; i++) {
+      StringAdd(s, CharToString(buf[i]));
+   }
+   // ToDo Overflow prodection!
+   return ((int) StringToInteger(s));
+}
 //+------------------------------------------------------------------+
 //|                                                                  |
 //+------------------------------------------------------------------+
-int MqlNet::GetHTTPStatusCode(int hRequest)
-  {
-   if(!CheckTerminal()) return -1;
+int MqlNet::GetHTTPStatusCode(int hRequest) {
+   if (!CheckTerminal())
+      return -1;
    uchar cBuff[32];
-   int cBuffLength=32;
-   int cBuffIndex=0;
-   bool Res=HttpQueryInfoW(hRequest,HTTP_QUERY_STATUS_CODE,cBuff,cBuffLength,cBuffIndex);
-   if(!Res) { int lastError=Kernel32::GetLastError(); Print("-Err QueryInfo (Status)" + (string) lastError); return(-1); }
-   string s="";
-   for(int i=0;i<cBuffLength;i++)
-     {
-      StringAdd(s,CharToString(cBuff[i]));
-     }
+   int cBuffLength = 32;
+   int cBuffIndex = 0;
+   bool Res = HttpQueryInfoW(hRequest, HTTP_QUERY_STATUS_CODE, cBuff, cBuffLength, cBuffIndex);
+   if (!Res) {
+      int lastError = Kernel32::GetLastError();
+      Print("-Err QueryInfo (Status)" + (string) lastError);
+      return (-1);
+   }
+   string s = "";
+   for (int i = 0; i < cBuffLength; i++) {
+      StringAdd(s, CharToString(cBuff[i]));
+   }
    StringTrimRight(s);
-   int http_code=(int) StringToInteger(s);
+   int http_code = (int) StringToInteger(s);
    return http_code;
-  }
+}
 //+------------------------------------------------------------------+
 //|                                                                  |
 //+------------------------------------------------------------------+
-string MqlNet::GetHTTPHeaders(int hRequest)
-  {
-   if(!CheckTerminal()){return "";}
+string MqlNet::GetHTTPHeaders(int hRequest) {
+   if (!CheckTerminal()) {
+      return "";
+   }
    uchar cBuff[1024];
-   int cBuffLength=1024;
-   int cBuffIndex=0;
-   HttpQueryInfoW(hRequest,HTTP_QUERY_RAW_HEADERS_CRLF,cBuff,cBuffLength,cBuffIndex);
-   string s="";
-//This is a workaround because CharArrayToString does somehow not work...
-   for(int i=0;i<cBuffLength;i++)
-     {
-      StringAdd(s,CharToString(cBuff[i]));
-     }
+   int cBuffLength = 1024;
+   int cBuffIndex = 0;
+   HttpQueryInfoW(hRequest, HTTP_QUERY_RAW_HEADERS_CRLF, cBuff, cBuffLength, cBuffIndex);
+   string s = "";
+   // This is a workaround because CharArrayToString does somehow not work...
+   for (int i = 0; i < cBuffLength; i++) {
+      StringAdd(s, CharToString(cBuff[i]));
+   }
    StringTrimRight(s);
    return s;
-  }
+}
 //+------------------------------------------------------------------+
 //|                                                                  |
 //+------------------------------------------------------------------+
-bool MqlNet::CheckTerminal()
-  {
-   if(!TerminalInfoInteger(TERMINAL_DLLS_ALLOWED)) { Print("-DLL not allowed"); return(false); } // checking whether DLLs are allowed in the terminal
-   if(!MQL5InfoInteger(MQL5_DLLS_ALLOWED)) { Print("-DLL not allowed"); return(false); } // checking whether DLLs are allowed in the terminal
+bool MqlNet::CheckTerminal() {
+   if (!TerminalInfoInteger(TERMINAL_DLLS_ALLOWED)) {
+      Print("-DLL not allowed");
+      return (false);
+   }   // checking whether DLLs are allowed in the terminal
+   if (!MQL5InfoInteger(MQL5_DLLS_ALLOWED)) {
+      Print("-DLL not allowed");
+      return (false);
+   }   // checking whether DLLs are allowed in the terminal
    return true;
-  }
+}
 //+------------------------------------------------------------------+

--- a/Libraries/WebRequest2/WebRequest2.mq5
+++ b/Libraries/WebRequest2/WebRequest2.mq5
@@ -4,81 +4,84 @@
 //|                                     https://github.com/sirtoobii |
 //+------------------------------------------------------------------+
 #property copyright "Copyright © 2018, T.Bossert"
-#property link      "https://github.com/sirtoobii"
-#property version		"1.00"
+#property link "https://github.com/sirtoobii"
+#property version "1.00"
 #property library
 #include "InetHttp.mqh"
 MqlNet INet;
-int  WebRequest2(
-   const string      method,           // HTTP-Methode
-   const string      url,              // URL-Adresse
-   const string      headers,          // Headers 
-   int               timeout,          // Timeout
-   char              &data[],          // Array des Body einer HTTP-Nachricht
-   char              &result[],        // Array mit den Daten der Serverantwort
-   string            &result_headers,   // Headers der Serverantwort
-   const int         port=NULL,         //Define custom port
-   const bool        allowInsecure=false, //Allow self signed certs
-   const bool        useSSL=NULL          //Use SSL encrypted connection
-   ) export
-   {
-      Print(url);
-      int Port = port;
-      bool UseSSL = useSSL;
-      string Host = "";
-      string Path = "";
-      string lower_Url = url;
-      string Head = headers;
-      string file = "";
-         tagRequest req;
-      StringToLower(lower_Url);
-      int offset = 0;
-      //Determine Ports if not set
-      if ((StringFind(lower_Url, "http") == -1) && (port==NULL)){LogError(2,"Please specifiy eighter a port or Http(s) with the url parameter"); return -1;}
-      if (port == NULL && StringFind(lower_Url, "https://") != -1)
-      {
-         Port = 443;
-         UseSSL = true;   
-      }else if(port == NULL)
-      {
-         Port = 80;
-         UseSSL = false;
-      }
-      //Remove http(s):// and define offset for spliting
-      if (StringReplace(lower_Url, "https://", "")){offset = 8;}
-      if (StringReplace(lower_Url, "http://", "")) {offset = 7;}
-      //Determine host and path from url parameter
-      int path_start = StringFind(lower_Url, "/", 0);
-      if (path_start > 0)
-      {
-         Host = StringSubstr(lower_Url, 0, path_start);
-         Path = StringSubstr(url, path_start+offset);
-         LogError(0, "Set Host to: " +Host+ " and Path: " +Path+ " with Port: " +IntegerToString(Port) + " SSL=" + (string) UseSSL + " Insecure=" + (string) allowInsecure);
-      }else{
-         Host = lower_Url;
-         LogError(0, "Set Host to: " +Host+ " with Port: " +IntegerToString(Port) + " SSL=" + (string) UseSSL + " Insecure=" + (string) allowInsecure);
-      }
-      //Open connection
-      if (!INet.Open(Host, Port, "", "", INTERNET_SERVICE_HTTP)) return -1;
-      if (method=="GET")  req.Init(method, Path,          Head, "",   false, file, false, UseSSL, allowInsecure);
-      if (method=="POST") req.Init(method, Path,          Head, "", false, file, false, UseSSL, allowInsecure);
-      INet.Request(req, data, result);
-      result_headers = req.resHeader;
-      return req.resCode;
+int WebRequest2(const string method,                // HTTP-Methode
+                const string url,                   // URL-Adresse
+                const string headers,               // Headers
+                int timeout,                        // Timeout
+                char &data[],                       // Array des Body einer HTTP-Nachricht
+                char &result[],                     // Array mit den Daten der Serverantwort
+                string &result_headers,             // Headers der Serverantwort
+                const int port = NULL,              // Define custom port
+                const bool allowInsecure = false,   // Allow self signed certs
+                const bool useSSL = NULL            // Use SSL encrypted connection
+                ) export {
+   Print(url);
+   int Port = port;
+   bool UseSSL = useSSL;
+   string Host = "";
+   string Path = "";
+   string lower_Url = url;
+   string Head = headers;
+   string file = "";
+   tagRequest req;
+   StringToLower(lower_Url);
+   int offset = 0;
+   // Determine Ports if not set
+   if ((StringFind(lower_Url, "http") == -1) && (port == NULL)) {
+      LogError(2, "Please specifiy eighter a port or Http(s) with the url parameter");
+      return -1;
    }
-   
-void LogError(int level, string msg)
-{
-   switch(level)
-   {
-      case 0:
-         Print("++Webrequest2[INFO] " + msg);
-         break;
-      case 1:
-         Print("--Webrequest2[WARN] " + msg);
-         break;
-      case 2:
-         Print("--Webrequest2[ERROR] " + msg);
-         break;
+   if (port == NULL && StringFind(lower_Url, "https://") != -1) {
+      Port = 443;
+      UseSSL = true;
+   } else if (port == NULL) {
+      Port = 80;
+      UseSSL = false;
+   }
+   // Remove http(s):// and define offset for spliting
+   if (StringReplace(lower_Url, "https://", "")) {
+      offset = 8;
+   }
+   if (StringReplace(lower_Url, "http://", "")) {
+      offset = 7;
+   }
+   // Determine host and path from url parameter
+   int path_start = StringFind(lower_Url, "/", 0);
+   if (path_start > 0) {
+      Host = StringSubstr(lower_Url, 0, path_start);
+      Path = StringSubstr(url, path_start + offset);
+      LogError(0, "Set Host to: " + Host + " and Path: " + Path + " with Port: " + IntegerToString(Port) + " SSL=" + (string) UseSSL + " Insecure=" + (string) allowInsecure);
+   } else {
+      Host = lower_Url;
+      LogError(0, "Set Host to: " + Host + " with Port: " + IntegerToString(Port) + " SSL=" + (string) UseSSL + " Insecure=" + (string) allowInsecure);
+   }
+   // Open connection
+   if (!INet.Open(Host, Port, "", "", INTERNET_SERVICE_HTTP))
+      return -1;
+   if (method == "GET")
+      req.Init(method, Path, Head, "", false, file, false, UseSSL, allowInsecure);
+   if (method == "POST")
+      req.Init(method, Path, Head, "", false, file, false, UseSSL, allowInsecure);
+   INet.Request(req, data, result);
+   result_headers = req.resHeader;
+   return req.resCode;
+}
+
+void LogError(int level, string msg) {
+   switch (level) {
+   case 0:
+      Print("++Webrequest2[INFO] " + msg);
+      break;
+   case 1:
+      Print("--Webrequest2[WARN] " + msg);
+      break;
+   case 2:
+      Print("--Webrequest2[ERROR] " + msg);
+      break;
    }
 }

--- a/Scripts/TestWebRequest2.mq5
+++ b/Scripts/TestWebRequest2.mq5
@@ -1,7 +1,7 @@
-#property copyright     "Copyright 2023"
-#property link          ""
-#property version       "1.00"
-#property description   "TestWebRequest2"
+#property copyright "Copyright 2023"
+#property link ""
+#property version "1.00"
+#property description "TestWebRequest2"
 
 #include "../Libraries/WebRequest2/WebRequest2.mq5"
 


### PR DESCRIPTION
Add a `.clang-format` file to beautify the files.

Files have been beautified using the following commands:

```bash
$ cd webrequest2
$ clang-format.exe -i Libraries/WebRequest2/*.mqh
$ clang-format.exe -i Libraries/WebRequest2/*.mq5
$ clang-format.exe -i Scripts/TestWebRequest2.mq5
```

We can adjust the formatting settings in the `.clang-format` file if there's anything that you don't like.

More details here : https://clang.llvm.org/docs/ClangFormatStyleOptions.html